### PR TITLE
add support for :bitcoin and :ripple alphabets

### DIFF
--- a/lib/base58.rb
+++ b/lib/base58.rb
@@ -5,29 +5,36 @@
 
 class Base58
 
-  ALPHABET = "123456789abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ"
-  BASE = ALPHABET.length
+  # See https://en.wikipedia.org/wiki/Base58
+  ALPHABETS = {
+    :flickr => "123456789abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ", # This is the default
+    :bitcoin => "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz", # Also used for IPFS
+    :ripple => "rpshnaf39wBUDNEGHJKLM4PQRST7VWXYZ2bcdeCg65jkm8oFqi1tuvAxyz"
+  }
+  BASE = ALPHABETS[:flickr].length
 
   # Converts a base58 string to a base10 integer.
-  def self.base58_to_int(base58_val)
+  def self.base58_to_int(base58_val, alphabet = :flickr)
+    raise ArgumentError, 'Invalid alphabet selection.' unless ALPHABETS.include?(alphabet)
     int_val = 0
     base58_val.reverse.split(//).each_with_index do |char,index|
-      raise ArgumentError, 'Value passed not a valid Base58 String.' if (char_index = ALPHABET.index(char)).nil?
+      raise ArgumentError, 'Value passed not a valid Base58 String.' if (char_index = ALPHABETS[alphabet].index(char)).nil?
       int_val += (char_index)*(BASE**(index))
     end
     int_val
   end
 
   # Converts a base10 integer to a base58 string.
-  def self.int_to_base58(int_val)
+  def self.int_to_base58(int_val, alphabet = :flickr)
     raise ArgumentError, 'Value passed is not an Integer.' unless int_val.is_a?(Integer)
+    raise ArgumentError, 'Invalid alphabet selection.' unless ALPHABETS.include?(alphabet)
     base58_val = ''
     while(int_val >= BASE)
       mod = int_val % BASE
-      base58_val = ALPHABET[mod,1] + base58_val
+      base58_val = ALPHABETS[alphabet][mod,1] + base58_val
       int_val = (int_val - mod)/BASE
     end
-    ALPHABET[int_val,1] + base58_val
+    ALPHABETS[alphabet][int_val,1] + base58_val
   end
   
   class << self

--- a/test/test_base58.rb
+++ b/test/test_base58.rb
@@ -3,7 +3,9 @@ require 'base58'
 
 class TestBase58 < Test::Unit::TestCase
 
-EXAMPLES =  { "6hKMCS" => 3471391110,
+EXAMPLES =  {
+  :flickr => {
+              "6hKMCS" => 3471391110,
               "6hDrmR" => 3470152229,
               "6hHHZB" => 3470988633,
               "6hHKum" => 3470993664,
@@ -502,16 +504,50 @@ EXAMPLES =  { "6hKMCS" => 3471391110,
               "6hGMH7" => 3470806020,
               "6hGp5L" => 3470729904,
               "6hFfRV" => 3470507135,
-              "6hESHt" => 3470432637 }
+              "6hESHt" => 3470432637
+    },
+    :bitcoin => {
+              "6Hknds" => 3471391110,
+              "6HeSMr" => 3470152229,
+              "6Hiizc" => 3470988633,
+              "6HikVM" => 3470993664,
+              "6HmGgw" => 3471485480,
+              "6Hcrkr" => 3469844075
+    },
+    :ripple => {
+              "aHk8d1" => 3471391110,
+              "aHeSMi" => 3470152229,
+              "aH55zc" => 3470988633,
+              "aH5kVM" => 3470993664,
+              "aHmGgA" => 3471485480,
+              "aHciki" => 3469844075
+    }
+  }
 
-  def test_int_to_base58
-    EXAMPLES.each do |expected, integer|
+  def test_int_to_base58_all_alphabets
+    EXAMPLES.each do |alphabet, examples|
+      examples.each do |expected, integer|
+        assert_equal expected, Base58.int_to_base58(integer, alphabet)
+      end
+    end
+  end
+
+  def test_base58_to_int_all_alphabets
+    EXAMPLES.each do |alphabet, examples|
+      examples.each do |base_58, expected|
+        assert_equal expected, Base58.base58_to_int(base_58, alphabet)
+      end
+    end
+  end
+
+  def test_int_to_base58_default_alphabet
+    EXAMPLES[:flickr].each do |expected, integer|
       assert_equal expected, Base58.int_to_base58(integer)
     end
   end  
 
-  def test_base58_to_int
-    EXAMPLES.each do |base_58, expected|
+  def test_base58_to_int_default_alphabet
+    EXAMPLES[:flickr].each do |base_58, expected|
       assert_equal expected, Base58.base58_to_int(base_58)
     end
   end


### PR DESCRIPTION
@dougal this replaces https://github.com/dougal/base58/pull/4 and implements your suggestion to support more alphabets and provide some tests.

This preserves the existing behavior as default, and allows the other alphabets to be selected with an optional argument.

According to the Wikipedia link you provided, the IPFS alphabet is the same as Bitcoin's alphabet.
  